### PR TITLE
making InitBlock optional, debug stream will not be initialized by default

### DIFF
--- a/src/core/QueryParser/QueryParserTokenManager.cs
+++ b/src/core/QueryParser/QueryParserTokenManager.cs
@@ -1257,9 +1257,9 @@ namespace Lucene.Net.QueryParsers
 		private int[] jjstateSet = new int[72];
 		protected internal char curChar;
 		/// <summary>Constructor. </summary>
-		public QueryParserTokenManager(ICharStream stream)
+        public QueryParserTokenManager(ICharStream stream, bool initBlock = false)
 		{
-			InitBlock();
+			if (initBlock) InitBlock();
 			input_stream = stream;
 		}
 		


### PR DESCRIPTION
This is related to performance commit.
BuildQuery was slow due to initialization of the debug stream in the QueryParserTokenManager class